### PR TITLE
Make Scala.js 1.x default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,30 @@
-.lib/
-dist/*
-resolution-cache/
-streams/
-lib_managed/
-src_managed/
-project/boot/
-project/plugins/project/
-project/target/
-project/project/
+# Scala
+*.class
+*.log
 target/
 
-plugin/bin/sbt
-
-# Scala-IDE specific
-.scala_dependencies
-.worksheet
-bin/
-.project
-.settings
-.classpath
-
-etarget/
+# SBT
+.cache
+.cache-main
+.history
+.lib/
+dist/
+project/target
+project/project
+metals.sbt
+.metals/
+.bloop/
+.bsp/
 
 # OS X
+
+.DS_Store
 
 # Sublime Text
 *.sublime-workspace
 *.sublime-project
 
-.DS_Store
+# Metals
 
-# Other
-# src/main/resources/application.conf
-.DS_STORE
-nb-configuration.xml
-
-# IDEA
-.idea/
-.idea_modules/
-*.iml
-
+# VSCode
+*.code-workspace

--- a/data-tools/.scalafmt.conf
+++ b/data-tools/.scalafmt.conf
@@ -1,0 +1,6 @@
+version = "2.0.0-RC4"
+align = more
+maxColumn = 120
+align.openParenCallSite = true
+align.openParenDefnSite = true
+rewrite.rules = [AsciiSortImports, SortModifiers]

--- a/data-tools/.scalafmt.conf
+++ b/data-tools/.scalafmt.conf
@@ -1,6 +1,8 @@
-version = "2.0.0-RC4"
+version = "2.6.3"
 align = more
 maxColumn = 120
 align.openParenCallSite = true
 align.openParenDefnSite = true
+continuationIndent.extendSite = 4
+continuationIndent.withSiteRelativeToExtends = 2
 rewrite.rules = [AsciiSortImports, SortModifiers]

--- a/data-tools/common-data-tools.sbt
+++ b/data-tools/common-data-tools.sbt
@@ -6,10 +6,11 @@ resolvers += "Apache" at "https://repo.maven.apache.org/maven2"
 
 lazy val commonSettings = Seq(
   organization := "com.lkroll.common",
-  version := "1.3.1",
-  scalaVersion := "2.12.11",
+  version := "1.3.2",
+  scalaVersion := "2.13.5",
+  crossScalaVersions := Seq("2.12.13", "2.13.5"),
   libraryDependencies ++= Seq(
-  	"org.scalatest" %%% "scalatest" % "3.2.0" % "test"),
+  	"org.scalatest" %%% "scalatest" % "3.2.5" % "test"),
   bintrayOrganization := Some("lkrollcom"),
   licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 )

--- a/data-tools/common-data-tools.sbt
+++ b/data-tools/common-data-tools.sbt
@@ -2,21 +2,20 @@ enablePlugins(ScalaJSPlugin)
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 //scalacOptions in ThisBuild ++= Seq("-Ymacro-debug-verbose")
 
-resolvers += "Apache" at "http://repo.maven.apache.org/maven2"
+resolvers += "Apache" at "https://repo.maven.apache.org/maven2"
 
 lazy val commonSettings = Seq(
   organization := "com.lkroll.common",
-  version := "1.3.0",
-  scalaVersion := "2.12.8",
+  version := "1.3.1",
+  scalaVersion := "2.12.11",
   libraryDependencies ++= Seq(
-  	"org.scalatest" %%% "scalatest" % "3.0.4" % "test"),
+  	"org.scalatest" %%% "scalatest" % "3.2.0" % "test"),
   bintrayOrganization := Some("lkrollcom"),
   licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 )
 
 lazy val root = (project in file(".")).settings(
 	commonSettings,
-	EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.ManagedClasses,
 	name := "Common Data Tools Root",
 	skip in publish := true,
 ).aggregate(dataToolsJVM, dataToolsJS)
@@ -25,8 +24,6 @@ lazy val dataTools = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.
   settings(
 	  commonSettings,
 	  name := "Common Data Tools",
-	  EclipseKeys.useProjectId := true,
-    EclipseKeys.eclipseOutput := Some("./etarget"),
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
   ).
   jvmSettings(

--- a/data-tools/project/build.properties
+++ b/data-tools/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.4.7

--- a/data-tools/project/build.properties
+++ b/data-tools/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.0

--- a/data-tools/project/plugin.sbt
+++ b/data-tools/project/plugin.sbt
@@ -1,4 +1,7 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/data-tools/project/plugin.sbt
+++ b/data-tools/project/plugin.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 

--- a/data-tools/shared/src/main/scala/com/lkroll/common/collections/HashSetMultiMap.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/collections/HashSetMultiMap.scala
@@ -27,9 +27,9 @@ package com.lkroll.common.collections
 import scala.collection.mutable;
 
 /**
- * An implementation of MultiMap[A,B] with a HashMap as outer collection and HashSet as inner collection.
- */
-@SerialVersionUID(0x587bdc5a2595c9f1L)
+  * An implementation of MultiMap[A,B] with a HashMap as outer collection and HashSet as inner collection.
+  */
+@SerialVersionUID(6375931977208809969L)
 class HashSetMultiMap[A, B] extends MultiMap[A, B] with Serializable {
 
   type InnerCollection = mutable.HashSet[B];

--- a/data-tools/shared/src/main/scala/com/lkroll/common/collections/HashSetMultiMap.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/collections/HashSetMultiMap.scala
@@ -71,15 +71,12 @@ class HashSetMultiMap[A, B] extends MultiMap[A, B] with Serializable {
   }
   override def iterator: Iterator[(A, InnerCollection)] = inner.iterator;
   override def contains(key: A): Boolean = inner.contains(key);
-  override def entryExists(key: A, p: B => Boolean): Boolean = inner.get(key) match {
-    case Some(set) => set.exists(p)
-    case None      => false
-  }
+  override def entryExists(key: A, p: B => Boolean): Boolean =
+    inner.get(key) match {
+      case Some(set) => set.exists(p)
+      case None      => false
+    }
   override def keySet: KeySet = inner.keySet;
-
-  override def mkString(start: String, sep: String, end: String): String = inner.mkString(start, sep, end);
-  override def mkString(sep: String): String = inner.mkString(sep);
-  override def mkString: String = inner.mkString;
 }
 
 object HashSetMultiMap {

--- a/data-tools/shared/src/main/scala/com/lkroll/common/collections/MultiMap.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/collections/MultiMap.scala
@@ -25,13 +25,13 @@
 package com.lkroll.common.collections
 
 /**
- * An alternative <code>MultiMap</code> trait that uses multi-map semantics for the default map operations.
- *
- * For the standard library version, see [[scala.collection.mutable.MultiMap]].
- *
- * @tparam A key type
- * @tparam B value type (that is the values of the inner collection)
- */
+  * An alternative <code>MultiMap</code> trait that uses multi-map semantics for the default map operations.
+  *
+  * For the standard library version, see [[scala.collection.mutable.MultiMap]].
+  *
+  * @tparam A key type
+  * @tparam B value type (that is the values of the inner collection)
+  */
 trait MultiMap[A, B] extends Iterable[(A, Iterable[B])] {
 
   type InnerCollection <: Iterable[B];

--- a/data-tools/shared/src/main/scala/com/lkroll/common/collections/TreeSetMultiMap.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/collections/TreeSetMultiMap.scala
@@ -72,10 +72,11 @@ class TreeSetMultiMap[A: Ordering, B] extends MultiMap[A, B] with Serializable {
   }
   override def iterator: Iterator[(A, InnerCollection)] = inner.iterator;
   override def contains(key: A): Boolean = inner.contains(key);
-  override def entryExists(key: A, p: B => Boolean): Boolean = inner.get(key) match {
-    case Some(set) => set.exists(p)
-    case None      => false
-  }
+  override def entryExists(key: A, p: B => Boolean): Boolean =
+    inner.get(key) match {
+      case Some(set) => set.exists(p)
+      case None      => false
+    }
   override def keySet: KeySet = inner.keySet;
 
   def firstKey: A = inner.firstKey;
@@ -104,10 +105,6 @@ class TreeSetMultiMap[A: Ordering, B] extends MultiMap[A, B] with Serializable {
       None
     }
   }
-
-  override def mkString(start: String, sep: String, end: String): String = inner.mkString(start, sep, end);
-  override def mkString(sep: String): String = inner.mkString(sep);
-  override def mkString: String = inner.mkString;
 }
 
 object TreeSetMultiMap {

--- a/data-tools/shared/src/main/scala/com/lkroll/common/collections/TreeSetMultiMap.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/collections/TreeSetMultiMap.scala
@@ -27,9 +27,9 @@ package com.lkroll.common.collections
 import scala.collection.mutable;
 
 /**
- * An implementation of MultiMap[A,B] with a TreeMap as outer collection and HashSet as inner collection.
- */
-@SerialVersionUID(0xf1e2e397037e34c7L)
+  * An implementation of MultiMap[A,B] with a TreeMap as outer collection and HashSet as inner collection.
+  */
+@SerialVersionUID(-1017000328094141241L)
 class TreeSetMultiMap[A: Ordering, B] extends MultiMap[A, B] with Serializable {
 
   type InnerCollection = mutable.HashSet[B];

--- a/data-tools/shared/src/main/scala/com/lkroll/common/data/EditDistance.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/data/EditDistance.scala
@@ -27,9 +27,8 @@ package com.lkroll.common.data
 object EditDistance {
   def editDist[A](a: Iterable[A], b: Iterable[A]) =
     a.foldLeft((0 to b.size).toList)((prev, x) => {
-        (prev zip prev.tail zip b).scanLeft(prev.head + 1) {
-          case (h, ((d, v), y)) => Math.min(Math.min(h + 1, v + 1), d + (if (x == y) 0 else 1))
-        }
-      })
-      .last
+      (prev zip prev.tail zip b).scanLeft(prev.head + 1) {
+        case (h, ((d, v), y)) => Math.min(Math.min(h + 1, v + 1), d + (if (x == y) 0 else 1))
+      }
+    }).last
 }

--- a/data-tools/shared/src/main/scala/com/lkroll/common/data/EditDistance.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/data/EditDistance.scala
@@ -27,10 +27,9 @@ package com.lkroll.common.data
 object EditDistance {
   def editDist[A](a: Iterable[A], b: Iterable[A]) =
     a.foldLeft((0 to b.size).toList)((prev, x) => {
-      (prev zip prev.tail zip b).scanLeft(prev.head + 1) {
-        case (h, ((d, v), y)) => Math.min(
-          Math.min(h + 1, v + 1),
-          d + (if (x == y) 0 else 1))
-      }
-    }).last
+        (prev zip prev.tail zip b).scanLeft(prev.head + 1) {
+          case (h, ((d, v), y)) => Math.min(Math.min(h + 1, v + 1), d + (if (x == y) 0 else 1))
+        }
+      })
+      .last
 }

--- a/data-tools/shared/src/main/scala/com/lkroll/common/result/Result.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/result/Result.scala
@@ -71,10 +71,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     *
     * Discards the error value, if any.
     */
-  def ok(): Option[V] = this match {
-    case Ok(v)  => Some(v)
-    case Err(_) => None
-  }
+  def ok(): Option[V] =
+    this match {
+      case Ok(v)  => Some(v)
+      case Err(_) => None
+    }
 
   /**
     * Converts from `Result[V, E]` to `Option[V]`.
@@ -90,10 +91,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     *
     * Discards the success value, if any.
     */
-  def err(): Option[E] = this match {
-    case Ok(_)  => None
-    case Err(e) => Some(e)
-  }
+  def err(): Option[E] =
+    this match {
+      case Ok(_)  => None
+      case Err(e) => Some(e)
+    }
 
   /**
     * Converts from `Result[V, E]` to `Try[V]`.
@@ -102,11 +104,12 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     * then it produces a `Failure[E]`.
     * For other `E` it produces the same output as `Try(this.get)` would.
     */
-  def toTry: Try[V] = this match {
-    case Ok(v)             => Success(v)
-    case Err(e: Throwable) => Failure(e)
-    case Err(e)            => Try(this.get)
-  }
+  def toTry: Try[V] =
+    this match {
+      case Ok(v)             => Success(v)
+      case Err(e: Throwable) => Failure(e)
+      case Err(e)            => Try(this.get)
+    }
 
   /**
     * Maps a `Result[V,E]` to `Result[T,E]`
@@ -115,10 +118,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     *
     * This function can be used to compose the results of two functions.
     */
-  def map[T](f: V => T): Result[T, E] = this match {
-    case Ok(v)  => Ok(f(v))
-    case Err(e) => Err(e)
-  }
+  def map[T](f: V => T): Result[T, E] =
+    this match {
+      case Ok(v)  => Ok(f(v))
+      case Err(e) => Err(e)
+    }
 
   /**
     * Maps a `Result[V,E]` to `Result[V,F]`
@@ -127,29 +131,32 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     *
     * This function can be used to pass through a successful result while handling an error.
     */
-  def mapErr[F](f: E => F): Result[V, F] = this match {
-    case Ok(v)  => Ok(v)
-    case Err(e) => Err(f(e))
-  }
+  def mapErr[F](f: E => F): Result[V, F] =
+    this match {
+      case Ok(v)  => Ok(v)
+      case Err(e) => Err(f(e))
+    }
 
   /**
     * Allows merging of the ok and error values into a type `T`.
     *
     * `T` must be a common super type of both `V` and `E`.
     */
-  def merge[T](implicit ev: V <:< T, ev2: E <:< T): T = this match {
-    case Ok(v)  => v
-    case Err(e) => e
-  }
+  def merge[T](implicit ev: V <:< T, ev2: E <:< T): T =
+    this match {
+      case Ok(v)  => v
+      case Err(e) => e
+    }
 
   /**
     * Returns `res` if the result is [[com.lkroll.common.result.Ok Ok]],
     * otherwise returns the [[com.lkroll.common.result.Err Err]] value of `this`.
     */
-  def and[T, E1 >: E](res: Result[T, E1]): Result[T, E1] = this match {
-    case Ok(_)  => res
-    case Err(_) => this.asInstanceOf[Result[T, E1]]
-  }
+  def and[T, E1 >: E](res: Result[T, E1]): Result[T, E1] =
+    this match {
+      case Ok(_)  => res
+      case Err(_) => this.asInstanceOf[Result[T, E1]]
+    }
 
   /**
     * Returns `res` if the result is [[com.lkroll.common.result.Err Err]],
@@ -160,10 +167,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     * it is recommended to use [[com.lkroll.common.result.Result#orElse]],
     * which is lazily evaluated.
     */
-  def or[V1 >: V, E1 >: E](res: Result[V1, E1]): Result[V1, E1] = this match {
-    case Ok(_)  => this.asInstanceOf[Result[V1, E1]]
-    case Err(_) => res
-  }
+  def or[V1 >: V, E1 >: E](res: Result[V1, E1]): Result[V1, E1] =
+    this match {
+      case Ok(_)  => this.asInstanceOf[Result[V1, E1]]
+      case Err(_) => res
+    }
 
   /**
     * Calls `op` if the result is [[com.lkroll.common.result.Ok Ok]],
@@ -171,10 +179,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     *
     * This function can be used for control flow based on `Result` values.
     */
-  def flatMap[T, E1 >: E](op: V => Result[T, E1]): Result[T, E1] = this match {
-    case Ok(v)  => op(v)
-    case Err(_) => this.asInstanceOf[Result[T, E1]]
-  }
+  def flatMap[T, E1 >: E](op: V => Result[T, E1]): Result[T, E1] =
+    this match {
+      case Ok(v)  => op(v)
+      case Err(_) => this.asInstanceOf[Result[T, E1]]
+    }
 
   /**
     * Calls `op` if the result is [[com.lkroll.common.result.Ok Ok]],
@@ -190,19 +199,21 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     *
     * This function can be used for control flow based on result values.
     */
-  def orElse[V1 >: V, F](op: E => Result[V1, F]): Result[V1, F] = this match {
-    case Ok(_)  => this.asInstanceOf[Result[V1, F]]
-    case Err(e) => op(e)
-  }
+  def orElse[V1 >: V, F](op: E => Result[V1, F]): Result[V1, F] =
+    this match {
+      case Ok(_)  => this.asInstanceOf[Result[V1, F]]
+      case Err(e) => op(e)
+    }
 
   /**
     * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
     * Else, it returns `default`.
     */
-  def getOrElse[V1 >: V](default: => V1): V1 = this match {
-    case Ok(v)  => v
-    case Err(_) => default
-  }
+  def getOrElse[V1 >: V](default: => V1): V1 =
+    this match {
+      case Ok(v)  => v
+      case Err(_) => default
+    }
 
   /**
     * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
@@ -210,10 +221,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Err Err]]
     * using a standard error message plus the content of the `Err`.
     */
-  def get[V1 >: V]: V1 = this match {
-    case Ok(v)  => v
-    case Err(e) => throw new NoSuchElementException(s"Result.get on Err($e)")
-  }
+  def get[V1 >: V]: V1 =
+    this match {
+      case Ok(v)  => v
+      case Err(e) => throw new NoSuchElementException(s"Result.get on Err($e)")
+    }
 
   /**
     * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
@@ -221,19 +233,21 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Err Err]]
     * using the provided error message.
     */
-  def expect[V1 >: V](msg: String): V1 = this match {
-    case Ok(v)  => v
-    case Err(_) => throw new NoSuchElementException(msg)
-  }
+  def expect[V1 >: V](msg: String): V1 =
+    this match {
+      case Ok(v)  => v
+      case Err(_) => throw new NoSuchElementException(msg)
+    }
 
   /**
     * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
     * Else, it returns `default`.
     */
-  def getErrOrElse[E1 >: E](default: => E1): E1 = this match {
-    case Ok(_)  => default
-    case Err(e) => e
-  }
+  def getErrOrElse[E1 >: E](default: => E1): E1 =
+    this match {
+      case Ok(_)  => default
+      case Err(e) => e
+    }
 
   /**
     * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
@@ -241,10 +255,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Ok Ok]]
     * using a standard error message plus the content of the `Ok`.
     */
-  def getErr[E1 >: E]: E1 = this match {
-    case Ok(v)  => throw new NoSuchElementException(s"Result.getErr on Ok($v)")
-    case Err(e) => e
-  }
+  def getErr[E1 >: E]: E1 =
+    this match {
+      case Ok(v)  => throw new NoSuchElementException(s"Result.getErr on Ok($v)")
+      case Err(e) => e
+    }
 
   /**
     * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
@@ -252,10 +267,11 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
     * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Ok Ok]]
     * using the provided error message.
     */
-  def expectErr[E1 >: E](msg: String): E1 = this match {
-    case Ok(_)  => throw new NoSuchElementException(msg)
-    case Err(e) => e
-  }
+  def expectErr[E1 >: E](msg: String): E1 =
+    this match {
+      case Ok(_)  => throw new NoSuchElementException(msg)
+      case Err(e) => e
+    }
 }
 
 object Result {
@@ -274,10 +290,11 @@ object Result {
     *
     * Maps `Success` to `Ok` and `Failure` to `Err`.
     */
-  def fromTry[V](t: Try[V]): Result[V, Throwable] = t match {
-    case Success(v) => Ok(v)
-    case Failure(e) => Err(e)
-  };
+  def fromTry[V](t: Try[V]): Result[V, Throwable] =
+    t match {
+      case Success(v) => Ok(v)
+      case Failure(e) => Err(e)
+    };
 
   /**
     * Converts an `Option` to a `Result`.

--- a/data-tools/shared/src/main/scala/com/lkroll/common/result/Result.scala
+++ b/data-tools/shared/src/main/scala/com/lkroll/common/result/Result.scala
@@ -24,81 +24,84 @@
  */
 package com.lkroll.common.result
 
-import scala.util.{ Try, Success, Failure }
+import scala.util.{Failure, Success, Try}
 
 /**
- * A [[https://doc.rust-lang.org/std/result/index.html Rust-style]] `Result` type for error handling.
- *
- * It works essentially like Scala's `Either`, just with sensible naming,
- * and the "success" type argument coming first, as one would expect.
- *
- * The two possible variants are called [[com.lkroll.common.result.Ok Ok]]
- * and [[com.lkroll.common.result.Err Err]].
- *
- *  For example, you could use `Result[Int, String]` to indicate whether a
- *  received input is an `Int`, as expected, or fall back to reproducing the
- *  input as a `String` in the error case.
- *
- *  {{{
- *  import scala.io.StdIn._
- *  val in = readLine("Type an Int: ")
- *  val result: Result[Int, String] =
- *    try Ok(in.toInt)
- *    catch {
- *       case e: NumberFormatException => Err(in)
- *    }
- *
- *  result match {
- *    case Ok(x) => s"You passed me the Int: $x, which I will increment. $x + 1 = ${x+1}"
- *    case Err(x)  => s"You passed me the String: $x"
- *  }
- *  }}}
- */
+  * A [[https://doc.rust-lang.org/std/result/index.html Rust-style]] `Result` type for error handling.
+  *
+  * It works essentially like Scala's `Either`, just with sensible naming,
+  * and the "success" type argument coming first, as one would expect.
+  *
+  * The two possible variants are called [[com.lkroll.common.result.Ok Ok]]
+  * and [[com.lkroll.common.result.Err Err]].
+  *
+  *  For example, you could use `Result[Int, String]` to indicate whether a
+  *  received input is an `Int`, as expected, or fall back to reproducing the
+  *  input as a `String` in the error case.
+  *
+  *  {{{
+  *  import scala.io.StdIn._
+  *  val in = readLine("Type an Int: ")
+  *  val result: Result[Int, String] =
+  *    try Ok(in.toInt)
+  *    catch {
+  *       case e: NumberFormatException => Err(in)
+  *    }
+  *
+  *  result match {
+  *    case Ok(x) => s"You passed me the Int: $x, which I will increment. $x + 1 = ${x+1}"
+  *    case Err(x)  => s"You passed me the String: $x"
+  *  }
+  *  }}}
+  */
 sealed abstract class Result[+V, +E] extends Product with Serializable {
 
   /**
-   * Checks whether or not this is an instance of [[com.lkroll.common.result.Ok Ok]].
-   */
+    * Checks whether or not this is an instance of [[com.lkroll.common.result.Ok Ok]].
+    */
   def isOk: Boolean;
+
   /**
-   * Checks whether or not this is an instance of [[com.lkroll.common.result.Err Err]].
-   */
+    * Checks whether or not this is an instance of [[com.lkroll.common.result.Err Err]].
+    */
   def isErr: Boolean;
 
   /**
-   * Converts from `Result[V, E]` to `Option[V]`.
-   *
-   * Discards the error value, if any.
-   */
+    * Converts from `Result[V, E]` to `Option[V]`.
+    *
+    * Discards the error value, if any.
+    */
   def ok(): Option[V] = this match {
     case Ok(v)  => Some(v)
     case Err(_) => None
   }
+
   /**
-   * Converts from `Result[V, E]` to `Option[V]`.
-   *
-   * Discards the error value, if any.
-   *
-   * Same as [[com.lkroll.common.result.Result#ok ok()]].
-   */
+    * Converts from `Result[V, E]` to `Option[V]`.
+    *
+    * Discards the error value, if any.
+    *
+    * Same as [[com.lkroll.common.result.Result#ok ok()]].
+    */
   def toOption: Option[V] = ok();
+
   /**
-   * Converts from `Result[V, E]` to `Option[E].
-   *
-   * Discards the success value, if any.
-   */
+    * Converts from `Result[V, E]` to `Option[E].
+    *
+    * Discards the success value, if any.
+    */
   def err(): Option[E] = this match {
     case Ok(_)  => None
     case Err(e) => Some(e)
   }
 
   /**
-   * Converts from `Result[V, E]` to `Try[V]`.
-   *
-   * If `E <: Throwable` and `this` is [[com.lkroll.common.result.Err Err]]
-   * then it produces a `Failure[E]`.
-   * For other `E` it produces the same output as `Try(this.get)` would.
-   */
+    * Converts from `Result[V, E]` to `Try[V]`.
+    *
+    * If `E <: Throwable` and `this` is [[com.lkroll.common.result.Err Err]]
+    * then it produces a `Failure[E]`.
+    * For other `E` it produces the same output as `Try(this.get)` would.
+    */
   def toTry: Try[V] = this match {
     case Ok(v)             => Success(v)
     case Err(e: Throwable) => Failure(e)
@@ -106,149 +109,149 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
   }
 
   /**
-   * Maps a `Result[V,E]` to `Result[T,E]`
-   * by applying a function to a contained [[com.lkroll.common.result.Ok Ok]] value,
-   * leaving an [[com.lkroll.common.result.Err Err]] value untouched.
-   *
-   * This function can be used to compose the results of two functions.
-   */
+    * Maps a `Result[V,E]` to `Result[T,E]`
+    * by applying a function to a contained [[com.lkroll.common.result.Ok Ok]] value,
+    * leaving an [[com.lkroll.common.result.Err Err]] value untouched.
+    *
+    * This function can be used to compose the results of two functions.
+    */
   def map[T](f: V => T): Result[T, E] = this match {
     case Ok(v)  => Ok(f(v))
     case Err(e) => Err(e)
   }
 
   /**
-   * Maps a `Result[V,E]` to `Result[V,F]`
-   * by applying a function to a contained [[com.lkroll.common.result.Err Err]] value,
-   * leaving an [[com.lkroll.common.result.Ok Ok]] value untouched.
-   *
-   * This function can be used to pass through a successful result while handling an error.
-   */
+    * Maps a `Result[V,E]` to `Result[V,F]`
+    * by applying a function to a contained [[com.lkroll.common.result.Err Err]] value,
+    * leaving an [[com.lkroll.common.result.Ok Ok]] value untouched.
+    *
+    * This function can be used to pass through a successful result while handling an error.
+    */
   def mapErr[F](f: E => F): Result[V, F] = this match {
     case Ok(v)  => Ok(v)
     case Err(e) => Err(f(e))
   }
 
   /**
-   * Allows merging of the ok and error values into a type `T`.
-   *
-   * `T` must be a common super type of both `V` and `E`.
-   */
+    * Allows merging of the ok and error values into a type `T`.
+    *
+    * `T` must be a common super type of both `V` and `E`.
+    */
   def merge[T](implicit ev: V <:< T, ev2: E <:< T): T = this match {
     case Ok(v)  => v
     case Err(e) => e
   }
 
   /**
-   * Returns `res` if the result is [[com.lkroll.common.result.Ok Ok]],
-   * otherwise returns the [[com.lkroll.common.result.Err Err]] value of `this`.
-   */
+    * Returns `res` if the result is [[com.lkroll.common.result.Ok Ok]],
+    * otherwise returns the [[com.lkroll.common.result.Err Err]] value of `this`.
+    */
   def and[T, E1 >: E](res: Result[T, E1]): Result[T, E1] = this match {
     case Ok(_)  => res
     case Err(_) => this.asInstanceOf[Result[T, E1]]
   }
 
   /**
-   * Returns `res` if the result is [[com.lkroll.common.result.Err Err]],
-   * otherwise returns the [[com.lkroll.common.result.Ok Ok]] value of `this`.
-   *
-   * Arguments passed to or are eagerly evaluated;
-   * if you are passing the result of a function call,
-   * it is recommended to use [[com.lkroll.common.result.Result#orElse]],
-   * which is lazily evaluated.
-   */
+    * Returns `res` if the result is [[com.lkroll.common.result.Err Err]],
+    * otherwise returns the [[com.lkroll.common.result.Ok Ok]] value of `this`.
+    *
+    * Arguments passed to or are eagerly evaluated;
+    * if you are passing the result of a function call,
+    * it is recommended to use [[com.lkroll.common.result.Result#orElse]],
+    * which is lazily evaluated.
+    */
   def or[V1 >: V, E1 >: E](res: Result[V1, E1]): Result[V1, E1] = this match {
     case Ok(_)  => this.asInstanceOf[Result[V1, E1]]
     case Err(_) => res
   }
 
   /**
-   * Calls `op` if the result is [[com.lkroll.common.result.Ok Ok]],
-   * otherwise returns the [[com.lkroll.common.result.Err Err]] value of `this`.
-   *
-   * This function can be used for control flow based on `Result` values.
-   */
+    * Calls `op` if the result is [[com.lkroll.common.result.Ok Ok]],
+    * otherwise returns the [[com.lkroll.common.result.Err Err]] value of `this`.
+    *
+    * This function can be used for control flow based on `Result` values.
+    */
   def flatMap[T, E1 >: E](op: V => Result[T, E1]): Result[T, E1] = this match {
     case Ok(v)  => op(v)
     case Err(_) => this.asInstanceOf[Result[T, E1]]
   }
 
   /**
-   * Calls `op` if the result is [[com.lkroll.common.result.Ok Ok]],
-   * otherwise returns the [[com.lkroll.common.result.Err Err]] value of `this`.
-   *
-   * Alias of [[com.lkroll.common.result.Result#flatMap]].
-   */
+    * Calls `op` if the result is [[com.lkroll.common.result.Ok Ok]],
+    * otherwise returns the [[com.lkroll.common.result.Err Err]] value of `this`.
+    *
+    * Alias of [[com.lkroll.common.result.Result#flatMap]].
+    */
   def andThen[T, E1 >: E](op: V => Result[T, E1]): Result[T, E1] = flatMap(op);
 
   /**
-   * Calls `op` if the result is [[com.lkroll.common.result.Err Err]],
-   * otherwise returns the [[com.lkroll.common.result.Ok Ok]] value of `this`.
-   *
-   * This function can be used for control flow based on result values.
-   */
+    * Calls `op` if the result is [[com.lkroll.common.result.Err Err]],
+    * otherwise returns the [[com.lkroll.common.result.Ok Ok]] value of `this`.
+    *
+    * This function can be used for control flow based on result values.
+    */
   def orElse[V1 >: V, F](op: E => Result[V1, F]): Result[V1, F] = this match {
     case Ok(_)  => this.asInstanceOf[Result[V1, F]]
     case Err(e) => op(e)
   }
 
   /**
-   * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
-   * Else, it returns `default`.
-   */
+    * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
+    * Else, it returns `default`.
+    */
   def getOrElse[V1 >: V](default: => V1): V1 = this match {
     case Ok(v)  => v
     case Err(_) => default
   }
 
   /**
-   * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
-   *
-   * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Err Err]]
-   * using a standard error message plus the content of the `Err`.
-   */
+    * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
+    *
+    * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Err Err]]
+    * using a standard error message plus the content of the `Err`.
+    */
   def get[V1 >: V]: V1 = this match {
     case Ok(v)  => v
     case Err(e) => throw new NoSuchElementException(s"Result.get on Err($e)")
   }
 
   /**
-   * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
-   *
-   * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Err Err]]
-   * using the provided error message.
-   */
+    * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Ok Ok]].
+    *
+    * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Err Err]]
+    * using the provided error message.
+    */
   def expect[V1 >: V](msg: String): V1 = this match {
     case Ok(v)  => v
     case Err(_) => throw new NoSuchElementException(msg)
   }
 
   /**
-   * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
-   * Else, it returns `default`.
-   */
+    * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
+    * Else, it returns `default`.
+    */
   def getErrOrElse[E1 >: E](default: => E1): E1 = this match {
     case Ok(_)  => default
     case Err(e) => e
   }
 
   /**
-   * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
-   *
-   * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Ok Ok]]
-   * using a standard error message plus the content of the `Ok`.
-   */
+    * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
+    *
+    * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Ok Ok]]
+    * using a standard error message plus the content of the `Ok`.
+    */
   def getErr[E1 >: E]: E1 = this match {
     case Ok(v)  => throw new NoSuchElementException(s"Result.getErr on Ok($v)")
     case Err(e) => e
   }
 
   /**
-   * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
-   *
-   * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Ok Ok]]
-   * using the provided error message.
-   */
+    * Unwraps a result, yielding the content of an [[com.lkroll.common.result.Err Err]].
+    *
+    * @throws java.util.NoSuchElementException for [[com.lkroll.common.result.Ok Ok]]
+    * using the provided error message.
+    */
   def expectErr[E1 >: E](msg: String): E1 = this match {
     case Ok(_)  => throw new NoSuchElementException(msg)
     case Err(e) => e
@@ -256,33 +259,34 @@ sealed abstract class Result[+V, +E] extends Product with Serializable {
 }
 
 object Result {
+
   /**
-   * Attempts to evaluate `f` and wrap the result in a `Result`.
-   *
-   * If the evaluation is successful with result `v`, returns `Ok(v)`.
-   *
-   * If an exception `e` is thrown during evaluation, returns `Err(e)`.
-   */
+    * Attempts to evaluate `f` and wrap the result in a `Result`.
+    *
+    * If the evaluation is successful with result `v`, returns `Ok(v)`.
+    *
+    * If an exception `e` is thrown during evaluation, returns `Err(e)`.
+    */
   def apply[V](f: => V): Result[V, Throwable] = fromTry(Try(f))
 
   /**
-   * Converts an `Try` to a `Result`.
-   *
-   * Maps `Success` to `Ok` and `Failure` to `Err`.
-   */
+    * Converts an `Try` to a `Result`.
+    *
+    * Maps `Success` to `Ok` and `Failure` to `Err`.
+    */
   def fromTry[V](t: Try[V]): Result[V, Throwable] = t match {
     case Success(v) => Ok(v)
     case Failure(e) => Err(e)
   };
 
   /**
-   * Converts an `Option` to a `Result`.
-   *
-   * If `o` is `Some(v)`, returns `Ok(v)`.
-   *
-   * If `o` is `None`, returns `Err(e)`,
-   * where `e` is the same error message `o.get` would have thrown.
-   */
+    * Converts an `Option` to a `Result`.
+    *
+    * If `o` is `Some(v)`, returns `Ok(v)`.
+    *
+    * If `o` is `None`, returns `Err(e)`,
+    * where `e` is the same error message `o.get` would have thrown.
+    */
   def fromOption[V](o: Option[V]): Result[V, Throwable] = fromTry(Try(o.get));
 }
 

--- a/data-tools/shared/src/test/scala/com/lkroll/common/collections/MultiMapTest.scala
+++ b/data-tools/shared/src/test/scala/com/lkroll/common/collections/MultiMapTest.scala
@@ -1,8 +1,10 @@
 package com.lkroll.common.collections
 
 import org.scalatest._
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should.Matchers
 
-class MultiMapTest extends FlatSpec with Matchers {
+class MultiMapTest extends AnyFlatSpec with Matchers {
 
   "A TreeSetMultiMap" should "allow multiple values" in {
     val map = TreeSetMultiMap.empty[Int, String];

--- a/data-tools/shared/src/test/scala/com/lkroll/common/collections/MultiMapTest.scala
+++ b/data-tools/shared/src/test/scala/com/lkroll/common/collections/MultiMapTest.scala
@@ -11,10 +11,10 @@ class MultiMapTest extends AnyFlatSpec with Matchers {
     map += (0 -> "a");
     map += (0 -> "b");
     map += (1 -> "c");
-    map(0) should contain ("a");
-    map(0) should contain ("b");
+    map(0) should contain("a");
+    map(0) should contain("b");
     map(0) should not contain ("c");
-    map(1) should contain ("c");
+    map(1) should contain("c");
     map(1) should not contain ("a");
     map(1) should not contain ("b");
   }
@@ -27,7 +27,7 @@ class MultiMapTest extends AnyFlatSpec with Matchers {
     map -= (0 -> "a");
     map -= 1;
     map(0) should not contain ("a");
-    map(0) should contain ("b");
+    map(0) should contain("b");
     map(0) should not contain ("c");
     map.get(1) shouldBe empty;
   }
@@ -37,10 +37,10 @@ class MultiMapTest extends AnyFlatSpec with Matchers {
     map += (0 -> "a");
     map += (1 -> "b");
     map += (3 -> "c");
-    map.firstKey should be (0);
-    map.lastKey should be (3);
-    map.floor(2) should contain (1);
-    map.ceil(2) should contain (3);
+    map.firstKey should be(0);
+    map.lastKey should be(3);
+    map.floor(2) should contain(1);
+    map.ceil(2) should contain(3);
   }
 
   it should "print cool stuff" in {
@@ -48,8 +48,8 @@ class MultiMapTest extends AnyFlatSpec with Matchers {
     map += (0 -> "a");
     map += (0 -> "b");
     map += (1 -> "c");
-    val s = map.mkString(",");
-    s should be ("0 -> Set(a, b),1 -> Set(c)");
+    val s = map.iterator.map(t => s"${t._1} -> Set${t._2.mkString("(", ", ", ")")}").mkString(",");
+    s should be("0 -> Set(a, b),1 -> Set(c)");
   }
 
   "A HashSetMultiMap" should "allow multiple values" in {
@@ -57,10 +57,10 @@ class MultiMapTest extends AnyFlatSpec with Matchers {
     map += (0 -> "a");
     map += (0 -> "b");
     map += (1 -> "c");
-    map(0) should contain ("a");
-    map(0) should contain ("b");
+    map(0) should contain("a");
+    map(0) should contain("b");
     map(0) should not contain ("c");
-    map(1) should contain ("c");
+    map(1) should contain("c");
     map(1) should not contain ("a");
     map(1) should not contain ("b");
   }
@@ -73,7 +73,7 @@ class MultiMapTest extends AnyFlatSpec with Matchers {
     map -= (0 -> "a");
     map -= 1;
     map(0) should not contain ("a");
-    map(0) should contain ("b");
+    map(0) should contain("b");
     map(0) should not contain ("c");
     map.get(1) shouldBe empty;
   }
@@ -83,8 +83,8 @@ class MultiMapTest extends AnyFlatSpec with Matchers {
     map += (0 -> "a");
     map += (0 -> "b");
     map += (1 -> "c");
-    val s = map.mkString(",");
-    s should be ("1 -> Set(c),0 -> Set(a, b)");
+    val s = map.iterator.map(t => s"${t._1} -> Set${t._2.mkString("(", ", ", ")")}").mkString(",");
+    s should (be("1 -> Set(c),0 -> Set(a, b)") or be("0 -> Set(a, b),1 -> Set(c)"));
   }
 
 }

--- a/data-tools/shared/src/test/scala/com/lkroll/common/data/WordMatchTests.scala
+++ b/data-tools/shared/src/test/scala/com/lkroll/common/data/WordMatchTests.scala
@@ -25,8 +25,10 @@
 package com.lkroll.common.data
 
 import org.scalatest._
+import org.scalatest.funsuite._
+import org.scalatest.matchers.should.Matchers
 
-class WordMatchTests extends FunSuite with Matchers {
+class WordMatchTests extends AnyFunSuite with Matchers {
   val w1 = "Word";
   val w2 = "World";
   val w3 = "Nothing";

--- a/data-tools/shared/src/test/scala/com/lkroll/common/macros/ListMacroTests.scala
+++ b/data-tools/shared/src/test/scala/com/lkroll/common/macros/ListMacroTests.scala
@@ -25,8 +25,10 @@
 package com.lkroll.common.macros
 
 import org.scalatest._
+import org.scalatest.funsuite._
+import org.scalatest.matchers.should.Matchers
 
-class ListMacroTests extends FunSuite with Matchers {
+class ListMacroTests extends AnyFunSuite with Matchers {
   test("Member listing should work.") {
     TestMe.list should contain (1);
     TestMe.list should contain (2);

--- a/data-tools/shared/src/test/scala/com/lkroll/common/result/ResultTests.scala
+++ b/data-tools/shared/src/test/scala/com/lkroll/common/result/ResultTests.scala
@@ -25,6 +25,8 @@
 package com.lkroll.common.result
 
 import org.scalatest._
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{ BePropertyMatcher, BePropertyMatchResult }
 
 import scala.util.{ Try, Success, Failure };
@@ -41,7 +43,7 @@ object CustomMatchers {
   val err = new ErrBePropertyMatcher;
 }
 
-class ResultTests extends FlatSpec with Matchers {
+class ResultTests extends AnyFlatSpec with Matchers {
   import CustomMatchers._;
 
   val r1: Result[Int, String] = Ok(-3);


### PR DESCRIPTION
We are phasing out support for Scala.js 0.6 builds and will in the future only build for 1.x.